### PR TITLE
post /api/electricity/calculate APIの不必要なbefore_actionの廃止

### DIFF
--- a/serverside_challenge_2/challenge/app/controllers/api/electricity/calculate_controller.rb
+++ b/serverside_challenge_2/challenge/app/controllers/api/electricity/calculate_controller.rb
@@ -1,7 +1,7 @@
 class Api::Electricity::CalculateController < ApplicationController
-  before_action :price_calculate, only: :create
-
   def create
+    @prices = price_calculate
+
     if @prices[:errors].present?
       render json: @prices[:errors], status: :bad_request
     else
@@ -16,6 +16,6 @@ class Api::Electricity::CalculateController < ApplicationController
   end
 
   def price_calculate
-    @prices = Plan.calc_prices(create_params[:amperage], create_params[:electricity_usage_kwh])
+    Plan.calc_prices(create_params[:amperage], create_params[:electricity_usage_kwh])
   end
 end

--- a/serverside_challenge_2/challenge/app/controllers/api/electricity/calculate_controller.rb
+++ b/serverside_challenge_2/challenge/app/controllers/api/electricity/calculate_controller.rb
@@ -1,7 +1,6 @@
 class Api::Electricity::CalculateController < ApplicationController
   def create
     @prices = price_calculate
-
     if @prices[:errors].present?
       render json: @prices[:errors], status: :bad_request
     else


### PR DESCRIPTION
こちらの実装意図は無く手癖になります。
普段はshow,update,destroy時の共通のfind処理をbefore_actionで実装しています。
検索処理は共通処理ではないですがbefore_actionで同様に実装する事があり、今回同様に実装していました。

私からの提案としてはbefore_actionを廃止しresponse前に移動致しました。
こちら別途PRとして作成致しましたため、お手数おかけしますが差分をご確認お願い致します。
