### PR TITLE
fix: 電力料金のプラン毎の計算ロジックの改善案

### DIFF
--- a/serverside_challenge_2/challenge/app/controllers/api/electricity/calculate_controller.rb
+++ b/serverside_challenge_2/challenge/app/controllers/api/electricity/calculate_controller.rb
@@ -16,6 +16,6 @@ class Api::Electricity::CalculateController < ApplicationController
   end
 
   def price_calculate
-    @prices = Plan.calc_prices(create_params[:amperage], create_params[:electricity_usage_kwh])
+    @prices = Plan.calc_plans(create_params[:amperage], create_params[:electricity_usage_kwh])
   end
 end

--- a/serverside_challenge_2/challenge/app/models/basic_price.rb
+++ b/serverside_challenge_2/challenge/app/models/basic_price.rb
@@ -11,12 +11,17 @@ class BasicPrice < ApplicationRecord
   validates :plan, presence: true, uniqueness: { scope: :amperage }
 
   class << self
-    def calc_prices(amperage)
-      rows = BasicPrice.where(amperage: amperage)
-      rows.inject({}) do |sum, row|
-        sum[row.plan_id] = row.price
-        sum
+    def calc_prices(plans_hash, amperage)
+      exists_ids = {}
+      rows = BasicPrice.where(amperage: amperage).where(plan_id: plans_hash.keys)
+      rows.each do |row|
+        exists_ids[row.plan_id] = true
+        plans_hash[row.plan_id][:price] += row.price
       end
+      plans_hash.keys.each do |key|
+        plans_hash.delete(key) if exists_ids[key].nil?
+      end
+      plans_hash
     end
 
     def check_amperage?(amperage)

--- a/serverside_challenge_2/challenge/spec/models/basic_price_spec.rb
+++ b/serverside_challenge_2/challenge/spec/models/basic_price_spec.rb
@@ -180,11 +180,12 @@ RSpec.describe BasicPrice, type: :model do
       end
 
       it 'amperageに対応するプランの料金を取得できる' do
-        res = BasicPrice.calc_prices(10)
+        plans_hash = Plan.send(:initial_plans_hash)
+        res = BasicPrice.calc_prices(plans_hash, 10)
 
         expect(res.keys.size).to eq 2
-        expect(res[plan1_provider1.id]).to eq 110.00
-        expect(res[plan2_provider1.id]).to eq 210.00
+        expect(res[plan1_provider1.id][:price]).to eq 110.00
+        expect(res[plan2_provider1.id][:price]).to eq 210.00
       end
     end
   end

--- a/serverside_challenge_2/challenge/spec/models/measure_rate_spec.rb
+++ b/serverside_challenge_2/challenge/spec/models/measure_rate_spec.rb
@@ -279,6 +279,7 @@ RSpec.describe MeasuredRate, type: :model do
     let(:plan1_provider1) { create(:plan, name: 'plan1', provider: provider1) }
     let(:plan2_provider1) { create(:plan, name: 'plan2', provider: provider1) }
     let(:plan3_provider2) { create(:plan, name: 'plan3', provider: provider2) }
+    let(:plans_hash) { Plan.send(:initial_plans_hash) }
 
     describe 'validate_electricity_usage?' do
       it '整数の場合エラーではないこと' do
@@ -392,7 +393,7 @@ RSpec.describe MeasuredRate, type: :model do
         end
 
         it '価格計算が妥当であること' do
-          res = MeasuredRate.calc_prices(1000)
+          res = MeasuredRate.calc_prices(plans_hash, 1000)
 
           expect(res.size).to eq 1
           expect(res[plan3_provider2.id][:price]).to eq 10000
@@ -408,14 +409,14 @@ RSpec.describe MeasuredRate, type: :model do
 
         context '1段階目の場合' do
           it '最小値の場合、価格計算が妥当であること' do
-            res = MeasuredRate.calc_prices(1)
+            res = MeasuredRate.calc_prices(plans_hash, 1)
 
             expect(res.size).to eq 1
             expect(res[plan1_provider1.id][:price]).to eq 19.88
           end
 
           it '最大値の場合、価格計算が妥当であること' do
-            res = MeasuredRate.calc_prices(120)
+            res = MeasuredRate.calc_prices(plans_hash, 120)
 
             expect(res.size).to eq 1
             expect(res[plan1_provider1.id][:price]).to eq 2385.6
@@ -424,14 +425,14 @@ RSpec.describe MeasuredRate, type: :model do
 
         context '2段階目の場合' do
           it '最小値の場合、価格計算が妥当であること' do
-            res = MeasuredRate.calc_prices(121)
+            res = MeasuredRate.calc_prices(plans_hash, 121)
 
             expect(res.size).to eq 1
             expect(res[plan1_provider1.id][:price]).to eq 2385.6 + 26.48
           end
 
           it '最大値の場合、価格計算が妥当であること' do
-            res = MeasuredRate.calc_prices(300)
+            res = MeasuredRate.calc_prices(plans_hash, 300)
 
             expect(res.size).to eq 1
             expect(res[plan1_provider1.id][:price]).to eq 2385.6 + 4766.4
@@ -440,14 +441,14 @@ RSpec.describe MeasuredRate, type: :model do
 
         context '3段階目の場合' do
           it '最小値の場合、価格計算が妥当であること' do
-            res = MeasuredRate.calc_prices(301)
+            res = MeasuredRate.calc_prices(plans_hash, 301)
 
             expect(res.size).to eq 1
             expect(res[plan1_provider1.id][:price]).to eq 2385.6 + 4766.4 + 30.57
           end
 
           it '最小値以上の場合、価格計算が妥当であること' do
-            res = MeasuredRate.calc_prices(500)
+            res = MeasuredRate.calc_prices(plans_hash, 500)
 
             expect(res.size).to eq 1
             expect(res[plan1_provider1.id][:price]).to eq 2385.6 + 4766.4 + 6114
@@ -467,7 +468,7 @@ RSpec.describe MeasuredRate, type: :model do
         end
 
         it '使用量の条件に合致する複数のプランが集計されること' do
-          res = MeasuredRate.calc_prices(301)
+          res = MeasuredRate.calc_prices(plans_hash, 301)
 
           expect(res.size).to eq 3
           expect(res[plan1_provider1.id][:price]).to eq 7840


### PR DESCRIPTION
料金計算に関して以下の観点を再検討しました。
- Planが計算の主体である
- MeasuredRateの抽出対象に不要なplanが含まれ非効率

アプローチとしては以下を考えました。
- プラン自体の料金, 基本料金, 従量料金の各modelで料金計算methodのインターフェースを統一し、一元的に呼び出し可能にする
- 基本料金の場合に契約Aが存在しないプランを除外し、従量料金の計算時に計算対象planが除外される
- 料金計算したい優先順に多段に計算を行い、料金が加算されていく
  - 計算ロジックのinterfaceを共通化することにより、計算対象のModelをループすることにより料金が計算される
- 各計算が終了後に小数点以下を切り捨てる

計算methodは以下の処理手順に統一する。
- args
  - plans_hash{ plan_id: { plan:, provider:, price: } }
  - value: 計算に利用する値
- return
  - plans{}
- 処理
  - 計算対象のデータの抽出
    - plan_idでの絞り込みも条件に付与する
  - Model毎にvalueと抽出したデータにより計算を行う
  - 基本料金の場合は条件によって結果からplanを取り除く
